### PR TITLE
Set watchOS deployment target to 2.0

### DIFF
--- a/SwiftPriorityQueue.podspec
+++ b/SwiftPriorityQueue.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
   s.tvos.deployment_target = '9.0'
+  s.watchos.deployment_target = '2.0'
   s.source_files = 'Sources/SwiftPriorityQueue.swift'
   s.requires_arc = true
 end


### PR DESCRIPTION
I just added a single line to the .podspec file to support watchOS platform. I'm not sure if this is enough for the support, can you kindly check and accept my pull request if so.