### PR TITLE
Performance improvement (addresses #15)

### DIFF
--- a/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
+++ b/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
@@ -68,7 +68,6 @@ internal func swap<T>(_ a: UnsafeMutablePointer<T>, _ b: UnsafeMutablePointer<T>
 internal func __push_heap_front<T>(_ first: UnsafeMutablePointer<T>, _ : UnsafeMutablePointer<T>, _ isOrderedBefore: (UnsafeMutablePointer<T>, UnsafeMutablePointer<T>) -> Bool,
                                    length: Int)
 {
-    typealias difference_type = Int
     if (length > 1)
     {
         var pIndex: Int = 0
@@ -170,18 +169,30 @@ internal func make_heap<T: Comparable>(_ first: UnsafeMutablePointer<T>, _ last:
 @inlinable
 internal func __heapify<T: Comparable>(_ first: UnsafeMutablePointer<T>, _ last: UnsafeMutablePointer<T>, _ isOrderedBefore: (UnsafeMutablePointer<T>, UnsafeMutablePointer<T>) -> Bool, _ length: Int) {
     var n = (length - 2) / 2
+    var i: Int
+    var j: Int
+    var iPointer: UnsafeMutablePointer<T>
+    var jPointer: UnsafeMutablePointer<T>
     while n >= 0 {
-        var i = n
-        while 2 * i + 1 < length {
+        i = n
+        j = 2 * i + 1
+        iPointer = first + i
+        jPointer = first + j
+        
+        while j < length {
             
-            var j = 2 * i + 1
+            if j < (length - 1) && isOrderedBefore(jPointer, jPointer + 1) {
+                j += 1
+                jPointer += 1
+            }
+            if !isOrderedBefore(iPointer, jPointer) { break }
             
-            if j < (length - 1) && isOrderedBefore(first + j, first + j + 1) { j += 1 }
-            if !isOrderedBefore(first + i, first + j) { break }
-            
-            swap(first + i, first + j)
+            swap(iPointer, jPointer)
             
             i = j
+            j = 2 * i + 1
+            iPointer = jPointer
+            jPointer = first + j
         }
         n -= 1
     }

--- a/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
+++ b/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
@@ -24,55 +24,17 @@
 
 // This code was inspired by Section 2.4 of Algorithms by Sedgewick & Wayne, 4th Edition
 
-prefix operator --
 
-prefix operator ++
-
-extension UnsafeMutablePointer {
-    
+internal extension UnsafeMutablePointer {
     
     /// Decrement and return
     ///
     /// Decrement the pointer by 1 and return the resulting pointer.
     /// - Parameter operand: operand
     @usableFromInline
-    static prefix func --(operand: inout UnsafeMutablePointer) -> UnsafeMutablePointer {
-        operand -= 1
-        return operand
-    }
-    
-    /// Increment and return
-    ///
-    /// Increment the pointer by 1 and return the resulting pointer.
-    /// - Parameter operand: operand
-    @usableFromInline
-    static prefix func ++(operand: inout UnsafeMutablePointer) -> UnsafeMutablePointer {
-        operand += 1
-        return operand
-    }
-}
-
-
-extension Int {
-    
-    /// Decrement and return
-    ///
-    /// Decrement the value by 1 and return the resulting value.
-    /// - Parameter operand: operand
-    @usableFromInline
-    static prefix func --(lhs: inout Int) -> Int {
-        lhs -= 1
-        return lhs
-    }
-    
-    /// Increment and return
-    ///
-    /// Increment the value by 1 and return the resulting value.
-    /// - Parameter operand: operand
-    @usableFromInline
-    static prefix func ++(lhs: inout Int) -> Int {
-        lhs += 1
-        return lhs
+    mutating func decrementAndReturn() -> UnsafeMutablePointer {
+        self -= 1
+        return self
     }
 }
 
@@ -104,14 +66,12 @@ internal func swap<T>(_ a: UnsafeMutablePointer<T>, _ b: UnsafeMutablePointer<T>
 @inlinable
 internal func __heapify<T>(_ first: UnsafeMutablePointer<T>, _ isOrderedAfter: (UnsafeMutablePointer<T>, UnsafeMutablePointer<T>) -> Bool, _ length: Int) {
     var n = (length - 2) / 2
-    var i: Int
     var j: Int
     var iPointer: UnsafeMutablePointer<T>
     var jPointer: UnsafeMutablePointer<T>
     while n >= 0 {
-        i = n
-        j = 2 * i + 1
-        iPointer = first + i
+        j = 2 * n + 1
+        iPointer = first + n
         jPointer = first + j
         
         while j < length {
@@ -124,8 +84,7 @@ internal func __heapify<T>(_ first: UnsafeMutablePointer<T>, _ isOrderedAfter: (
             
             swap(iPointer, jPointer)
             
-            i = j
-            j = 2 * i + 1
+            j = 2 * j + 1
             iPointer = jPointer
             jPointer = first + j
         }
@@ -208,7 +167,7 @@ internal func __push_heap_back<T>(_ first: UnsafeMutablePointer<T>, _ isOrderedA
     {
         len = (len - 2) / 2;
         var ptr = first + len;
-        if (isOrderedAfter(ptr, --last))
+        if (isOrderedAfter(ptr, last.decrementAndReturn()))
         {
             var t = last.move()
             repeat {

--- a/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
+++ b/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
@@ -25,30 +25,50 @@
 // This code was inspired by Section 2.4 of Algorithms by Sedgewick & Wayne, 4th Edition
 
 prefix operator --
+
 prefix operator ++
 
 extension UnsafeMutablePointer {
+    
+    
+    /// Decrement and return
+    ///
+    /// Decrement the pointer by 1 and return the resulting pointer.
+    /// - Parameter operand: operand
     @usableFromInline
-    static prefix func --(lhs: inout UnsafeMutablePointer) -> UnsafeMutablePointer {
-        lhs -= 1
-        return lhs
+    static prefix func --(operand: inout UnsafeMutablePointer) -> UnsafeMutablePointer {
+        operand -= 1
+        return operand
     }
     
+    /// Increment and return
+    ///
+    /// Increment the pointer by 1 and return the resulting pointer.
+    /// - Parameter operand: operand
     @usableFromInline
-    static prefix func ++(lhs: inout UnsafeMutablePointer) -> UnsafeMutablePointer {
-        lhs += 1
-        return lhs
+    static prefix func ++(operand: inout UnsafeMutablePointer) -> UnsafeMutablePointer {
+        operand += 1
+        return operand
     }
 }
 
 
 extension Int {
+    
+    /// Decrement and return
+    ///
+    /// Decrement the value by 1 and return the resulting value.
+    /// - Parameter operand: operand
     @usableFromInline
     static prefix func --(lhs: inout Int) -> Int {
         lhs -= 1
         return lhs
     }
     
+    /// Increment and return
+    ///
+    /// Increment the value by 1 and return the resulting value.
+    /// - Parameter operand: operand
     @usableFromInline
     static prefix func ++(lhs: inout Int) -> Int {
         lhs += 1
@@ -56,6 +76,12 @@ extension Int {
     }
 }
 
+
+/// Swap by reference
+///
+/// Swap the values pointed to by the two pointers.
+/// - Parameter a: first pointer
+/// - Parameter b: second pointer
 @usableFromInline
 internal func swap<T>(_ a: UnsafeMutablePointer<T>, _ b: UnsafeMutablePointer<T>) {
     let t = a.move()
@@ -63,104 +89,20 @@ internal func swap<T>(_ a: UnsafeMutablePointer<T>, _ b: UnsafeMutablePointer<T>
     b.initialize(to: t)
 }
 
-
+/// Heapify an array
+///
+/// Helper function for `SwiftPriorityQueue`.
+///
+/// Functionally equivalent to `heapify(array)`.
+///
+/// No assumptions are made about the initial order of the heap.
+/// - Parameter first: Pointer to the first element of the heap
+/// - Parameter isOrderedAfter: Ordering function. Returns true if `a.pointee` comes after `b.pointee`.
+/// - Parameter a: The first pointer
+/// - Parameter b: The second pointer
+/// - Parameter length: Length of the heap
 @inlinable
-internal func __push_heap_front<T>(_ first: UnsafeMutablePointer<T>, _ isOrderedBefore: (UnsafeMutablePointer<T>, UnsafeMutablePointer<T>) -> Bool,
-                                   _ length: Int)
-{
-    if (length > 1)
-    {
-        var pIndex: Int = 0
-        var pPointer = first
-        var cIndex: Int = 2
-        var cPointer = first + cIndex
-        if (cIndex == length || isOrderedBefore(cPointer, (cPointer - 1)))
-        {
-            cIndex -= 1
-            cPointer -= 1
-        }
-        if (isOrderedBefore(pPointer, cPointer))
-        {
-            var temp = pPointer.move()
-            repeat {
-                pPointer.moveInitialize(from: cPointer, count: 1)
-                pPointer = cPointer;
-                pIndex = cIndex;
-                cIndex = (pIndex + 1) * 2;
-                if (cIndex > length) {
-                    break;
-                }
-                cPointer = first + cIndex;
-                if (cIndex == length || isOrderedBefore(cPointer, (cPointer - 1)))
-                {
-                    cIndex -= 1
-                    cPointer -= 1
-                }
-            } while (isOrderedBefore(&temp, cPointer));
-            pPointer.initialize(to: temp)
-        }
-    }
-}
-
-@inlinable
-internal func __push_heap_back<T>(_ first: UnsafeMutablePointer<T>, _ isOrderedBefore: (UnsafeMutablePointer<T>, UnsafeMutablePointer<T>) -> Bool, _ length: Int)
-{
-    
-    var len = length
-    var last = first + length
-    
-    if (len > 1)
-    {
-        len = (len - 2) / 2;
-        var ptr = first + len;
-        if (isOrderedBefore(ptr, --last))
-        {
-            var t = last.move()
-            repeat {
-                last.moveInitialize(from: ptr, count: 1)
-                last = ptr;
-                if (len == 0) {
-                    break;
-                }
-                len = (len - 1) / 2;
-                ptr = first + len;
-            } while (isOrderedBefore(ptr, &t));
-            last.initialize(to: t)
-        }
-    }
-}
-
-@inlinable
-internal func __pop_heap<T>(_ first: UnsafeMutablePointer<T>, _ isOrderedBefore: (UnsafeMutablePointer<T>, UnsafeMutablePointer<T>) -> Bool, _ length: Int) {
-    let newLength = length - 1
-    let newLast = first + newLength
-    if length > 1 {
-        swap(first, newLast)
-        __push_heap_front(first, isOrderedBefore, newLength)
-    }
-}
-
-@inlinable
-internal func push_heap_back<T>(_ first: UnsafeMutablePointer<T>, _ length: Int, _ ordered: (T, T) -> Bool) {
-    __push_heap_back(first, {ordered($0.pointee, $1.pointee)}, length)
-}
-
-@inlinable
-internal func push_heap_back<T: Comparable>(_ first: UnsafeMutablePointer<T>, _ length: Int, _ ordered: (T, T) -> Bool = { $0 < $1 } ) {
-    __push_heap_back(first, {ordered($0.pointee, $1.pointee)}, length)
-}
-
-@inlinable
-internal func pop_heap<T>(_ first: UnsafeMutablePointer<T>, _ length: Int, _ ordered: (T, T) -> Bool) {
-    __pop_heap(first, {ordered($0.pointee, $1.pointee)}, length)
-}
-@inlinable
-internal func pop_heap<T: Comparable>(_ first: UnsafeMutablePointer<T>, _ length: Int, _ ordered: (T, T) -> Bool = { $0 < $1 } ) {
-    __pop_heap(first, {ordered($0.pointee, $1.pointee)}, length)
-}
-
-@inlinable
-internal func __heapify<T>(_ first: UnsafeMutablePointer<T>, _ isOrderedBefore: (UnsafeMutablePointer<T>, UnsafeMutablePointer<T>) -> Bool, _ length: Int) {
+internal func __heapify<T>(_ first: UnsafeMutablePointer<T>, _ isOrderedAfter: (UnsafeMutablePointer<T>, UnsafeMutablePointer<T>) -> Bool, _ length: Int) {
     var n = (length - 2) / 2
     var i: Int
     var j: Int
@@ -174,11 +116,11 @@ internal func __heapify<T>(_ first: UnsafeMutablePointer<T>, _ isOrderedBefore: 
         
         while j < length {
             
-            if j < (length - 1) && isOrderedBefore(jPointer, jPointer + 1) {
+            if j < (length - 1) && isOrderedAfter(jPointer, jPointer + 1) {
                 j += 1
                 jPointer += 1
             }
-            if !isOrderedBefore(iPointer, jPointer) { break }
+            if !isOrderedAfter(iPointer, jPointer) { break }
             
             swap(iPointer, jPointer)
             
@@ -191,12 +133,183 @@ internal func __heapify<T>(_ first: UnsafeMutablePointer<T>, _ isOrderedBefore: 
     }
 }
 
+/// Correctly position the first item of a heap
+///
+/// Helper function for `SwiftPriorityQueue`.
+///
+/// Equivalent to `sink(0)`. Assumes the remainder of the heap is valid.
+///
+/// - Parameter first: Pointer to the first element of the heap
+/// - Parameter isOrderedAfter: Ordering function. Returns true if `a.pointee` comes after `b.pointee`.
+/// - Parameter a: The first pointer
+/// - Parameter b: The second pointer
+/// - Parameter length: Length of the heap
+///
+/// - Note: Inspired by [libcxx/include/algorithm](https://github.com/google/libcxx/blob/master/include/algorithm)
 @inlinable
-internal func heapify<T>(_ first: UnsafeMutablePointer<T>, _ length: Int, ordered: (T, T) -> Bool) {
-    __heapify(first, {ordered($0.pointee, $1.pointee)}, length)
+internal func __push_heap_front<T>(_ first: UnsafeMutablePointer<T>, _ isOrderedAfter: (_ a: UnsafeMutablePointer<T>, _ b: UnsafeMutablePointer<T>) -> Bool,
+                                   _ length: Int)
+{
+    if (length > 1)
+    {
+        var pIndex: Int = 0
+        var pPointer = first
+        var cIndex: Int = 2
+        var cPointer = first + cIndex
+        if (cIndex == length || isOrderedAfter(cPointer, (cPointer - 1)))
+        {
+            cIndex -= 1
+            cPointer -= 1
+        }
+        if (isOrderedAfter(pPointer, cPointer))
+        {
+            var temp = pPointer.move()
+            repeat {
+                pPointer.moveInitialize(from: cPointer, count: 1)
+                pPointer = cPointer;
+                pIndex = cIndex;
+                cIndex = (pIndex + 1) * 2;
+                if (cIndex > length) {
+                    break;
+                }
+                cPointer = first + cIndex;
+                if (cIndex == length || isOrderedAfter(cPointer, (cPointer - 1)))
+                {
+                    cIndex -= 1
+                    cPointer -= 1
+                }
+            } while (isOrderedAfter(&temp, cPointer));
+            pPointer.initialize(to: temp)
+        }
+    }
 }
+
+/// Correctly position the last item of a heap
+///
+/// Helper function for `SwiftPriorityQueue`.
+///
+/// Functionally equivalent to `swim(length - 1)`. Assumes the remainder of the heap is valid.
+///
+/// - Parameter first: Pointer to the first element of the heap
+/// - Parameter isOrderedAfter: Ordering function. Returns true if `a.pointee` comes after `b.pointee`.
+/// - Parameter a: The first pointer
+/// - Parameter b: The second pointer
+/// - Parameter length: Length of the heap
+///
+/// - Note: Inspired by [libcxx/include/algorithm](https://github.com/google/libcxx/blob/master/include/algorithm)
 @inlinable
-internal func heapify<T: Comparable>(_ first: UnsafeMutablePointer<T>, _ length: Int, ordered: (T, T) -> Bool  = { $0 < $1 } ) {
+internal func __push_heap_back<T>(_ first: UnsafeMutablePointer<T>, _ isOrderedAfter: (_ a: UnsafeMutablePointer<T>, _ b: UnsafeMutablePointer<T>) -> Bool, _ length: Int)
+{
+    
+    var len = length
+    var last = first + length
+    
+    if (len > 1)
+    {
+        len = (len - 2) / 2;
+        var ptr = first + len;
+        if (isOrderedAfter(ptr, --last))
+        {
+            var t = last.move()
+            repeat {
+                last.moveInitialize(from: ptr, count: 1)
+                last = ptr;
+                if (len == 0) {
+                    break;
+                }
+                len = (len - 1) / 2;
+                ptr = first + len;
+            } while (isOrderedAfter(ptr, &t));
+            last.initialize(to: t)
+        }
+    }
+}
+
+/// Pop an item from the heap
+///
+/// Helper function for `SwiftPriorityQueue`.
+///
+/// Functionally equivalent to:
+///
+///     swapAt(0, length - 1)
+///     let temp = removeLast()
+///     sink(0)
+///     append(temp)
+///
+/// The popped item is moved to the end of the heap ready for removal. Assumes the remainder of the heap is valid.
+///
+///
+/// - Parameter first: Pointer to the first element of the heap
+/// - Parameter isOrderedAfter: Ordering function. Returns true if `a.pointee` comes after `b.pointee`.
+/// - Parameter a: The first pointer
+/// - Parameter b: The second pointer
+/// - Parameter length: Length of the heap
+///
+/// - Note: Inspired by [libcxx/include/algorithm](https://github.com/google/libcxx/blob/master/include/algorithm)
+@inlinable
+internal func __pop_heap<T>(_ first: UnsafeMutablePointer<T>, _ isOrderedAfter: (UnsafeMutablePointer<T>, UnsafeMutablePointer<T>) -> Bool, _ length: Int) {
+    let newLength = length - 1
+    let newLast = first + newLength
+    if length > 1 {
+        swap(first, newLast)
+        __push_heap_front(first, isOrderedAfter, newLength)
+    }
+}
+
+/// Correctly position the last item of a heap
+///
+/// Helper function for `SwiftPriorityQueue`.
+///
+/// Functionally equivalent to `swim(length - 1)`. Assumes the remainder of the heap is valid.
+///
+/// - Parameter first: Pointer to the first element of the heap
+/// - Parameter ordered: Ordering function. Returns true if `a` and `b` are correcly ordered. Defaults to `<`.
+/// - Parameter a: The first element
+/// - Parameter b: The second element
+/// - Parameter length: Length of the heap
+@inlinable
+internal func push_heap_back<T: Comparable>(_ first: UnsafeMutablePointer<T>, _ length: Int, _ ordered: (_ a: T, _ b: T) -> Bool = { $0 < $1 } ) {
+    __push_heap_back(first, {ordered($0.pointee, $1.pointee)}, length)
+}
+
+/// Pop an item from the heap
+///
+/// Helper function for `SwiftPriorityQueue`.
+///
+/// Functionally equivalent to:
+///
+///     swapAt(0, length - 1)
+///     let temp = removeLast()
+///     sink(0)
+///     append(temp)
+///
+/// The popped item is moved to the end of the heap ready for removal. Assumes the remainder of the heap is valid.
+///
+/// - Parameter first: Pointer to the first element of the heap
+/// - Parameter ordered: Ordering function. Returns true if `a` and `b` are correcly ordered. Defaults to `<`.
+/// - Parameter a: The first element
+/// - Parameter b: The second element
+/// - Parameter length: Length of the heap
+@inlinable
+internal func pop_heap<T: Comparable>(_ first: UnsafeMutablePointer<T>, _ length: Int, _ ordered: (_ a: T, _ b: T) -> Bool = { $0 < $1 } ) {
+    __pop_heap(first, {ordered($0.pointee, $1.pointee)}, length)
+}
+
+/// Heapify an array
+///
+/// Helper function for `SwiftPriorityQueue`
+///
+/// Functionally equivalent to: `heapify(array)`
+///
+/// No assumptions are made about the initial order of the heap.
+///
+/// - Parameter first: Pointer to the first element of the heap
+/// - Parameter ordered: Ordering function. Returns true if `a` and `b` are correcly ordered. Defaults to `<`.
+/// - Parameter a: The first element
+/// - Parameter b: The second element
+/// - Parameter length: Length of the heap
+@inlinable
+internal func heapify<T: Comparable>(_ first: UnsafeMutablePointer<T>, _ length: Int, ordered: (_ a: T, _ b: T) -> Bool = { $0 < $1 } ) {
     __heapify(first, {ordered($0.pointee, $1.pointee)}, length)
 }
 
@@ -225,8 +338,10 @@ public struct PriorityQueue<T: Comparable> {
     /// - parameter order: A function that specifies whether its first argument should
     ///                    come after the second argument in the PriorityQueue.
     /// - parameter startingValues: An array of elements to initialize the PriorityQueue with.
+    /// - parameter a: first argument
+    /// - parameter b: second argument
     @inlinable
-    public init(order: @escaping (T, T) -> Bool, startingValues: [T] = []) {
+    public init(order: @escaping (_ a: T, _ b: T) -> Bool, startingValues: [T] = []) {
         ordered = order
         
         // Based on "Heap construction" from Sedgewick p 323
@@ -408,30 +523,6 @@ public struct PriorityQueue<T: Comparable> {
     public mutating func clear() {
         heap.removeAll(keepingCapacity: false)
     }
-    
-    // Based on example from Sedgewick p 316
-    private mutating func sink(_ index: Int) {
-        var index = index
-        while 2 * index + 1 < heap.count {
-            
-            var j = 2 * index + 1
-            
-            if j < (heap.count - 1) && ordered(heap[j], heap[j + 1]) { j += 1 }
-            if !ordered(heap[index], heap[j]) { break }
-            
-            heap.swapAt(index, j)
-            index = j
-        }
-    }
-    
-    // Based on example from Sedgewick p 316
-    private mutating func swim(_ index: Int) {
-        var index = index
-        while index > 0 && ordered(heap[(index - 1) / 2], heap[index]) {
-            heap.swapAt((index - 1) / 2, index)
-            index = (index - 1) / 2
-        }
-    }
 }
 
 // MARK: - GeneratorType
@@ -476,8 +567,8 @@ extension PriorityQueue: Collection {
 extension PriorityQueue: CustomStringConvertible, CustomDebugStringConvertible {
     
     @inlinable
-    public var description: String { return heap.description }
+    public var description: String { return String(describing: heap) }
     
     @inlinable
-    public var debugDescription: String { return heap.debugDescription }
+    public var debugDescription: String { return String(reflecting: heap) }
 }

--- a/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
+++ b/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
@@ -156,6 +156,26 @@ class SwiftPriorityQueueTests: XCTestCase {
         XCTAssertEqual(expected, actual)
     }
     
+    func testBuildPerformance() {
+        var pq: PriorityQueue<Int> = PriorityQueue<Int>()
+        let input: [Int] = Array((0 ..< 100000))
+        measure {
+            pq = PriorityQueue(ascending: true, startingValues: input)
+        }
+        
+        let actual = Array(pq)
+        XCTAssertEqual(input, actual)
+    }
+    
+    func testPopPerformance() {
+        measure {
+            var pq = PriorityQueue(ascending: true, startingValues: Array(0 ..< 100000))
+            for _ in 0 ..< 100000 {
+                pq.pop()
+            }
+        }
+    }
+    
     static var allTests = [
         ("testCustomOrder", testCustomOrder),
         ("testBasic", testBasic),
@@ -165,6 +185,8 @@ class SwiftPriorityQueueTests: XCTestCase {
         ("testPeek", testPeek),
         ("testRemove", testRemove),
         ("testRemoveAll", testRemoveAll),
-        ("testRemoveLastInHeap", testRemoveLastInHeap)
+        ("testRemoveLastInHeap", testRemoveLastInHeap),
+        ("testBuildPerformance", testBuildPerformance),
+        ("testPopPerformance", testPopPerformance)
         ]
 }

--- a/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
+++ b/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
@@ -176,6 +176,24 @@ class SwiftPriorityQueueTests: XCTestCase {
         }
     }
     
+    func testPushPerformance() {
+        measure {
+            var pq = PriorityQueue<Int>(ascending: true, startingValues: [])
+            for i in 0 ..< 100000 {
+                pq.push(i)
+            }
+        }
+    }
+    
+    func testRemovePerformance() {
+        var pq = PriorityQueue(ascending: true, startingValues: Array(0 ..< 100000))
+        measure {
+            for _ in 0 ..< 100 {
+                pq.remove(pq.randomElement()!)
+            }
+        }
+    }
+    
     static var allTests = [
         ("testCustomOrder", testCustomOrder),
         ("testBasic", testBasic),
@@ -187,6 +205,8 @@ class SwiftPriorityQueueTests: XCTestCase {
         ("testRemoveAll", testRemoveAll),
         ("testRemoveLastInHeap", testRemoveLastInHeap),
         ("testBuildPerformance", testBuildPerformance),
-        ("testPopPerformance", testPopPerformance)
+        ("testPopPerformance", testPopPerformance),
+        ("testPushPerformance", testPushPerformance),
+        ("testRemovePerformance", testRemovePerformance)
         ]
 }


### PR DESCRIPTION
This update implements some lower-level functions to improve the performance of standard heap operations on `SwiftPriorityQueue` and adds performance tests for `init`, `pop`, `push` and `remove`. Hopefully the improvement is sufficient to close #15.

A naive implementation replacing `sink` and `swim` with versions that can be called from inside `Array.withUnsafeMutableBufferPointer(_:)` already gave promising performance for `init`, `pop` and `push`. (See [forked master branch](https://github.com/peteraisher/SwiftPriorityQueue/tree/master). This might represent a good compromise solution if the final code is deemed to be too complex.)

A more in-depth rewrite of the internal code (with inspiration from [libcxx/include/algorithm](https://github.com/google/libcxx/blob/master/include/algorithm)) gave further performance improvements, although the resulting code is less "easy" to understand. In an effort to aid readability, the new code is extensively (some might say excessively!) marked up.

Building a `SwiftPriorityQueue` from an `Array` of 100,000 values went from 17.8 ms to 4.1 ms.
Emptying a `SwiftPriorityQueue` with 100,000 values using `pop()` went from 2.11 s to 0.36 s.
Calling `remove(_:)` on 100 random items from a `SwiftPriorityQueue` with 100,000 values went from 2.36 s to 0.277 s.

Building a `SwiftPriorityQueue` by calling `push(_:)` 100,000 times went from 118 ms to 149 ms. Not certain what happened there! Further investigation may be required, but in any case, the performance improvement in `pop()` more than compensates in normal usage where `pop()` and `push(_:)` are called equally often.
 
<img width="760" alt="Performance Comparison SwiftPriorityQueue" src="https://user-images.githubusercontent.com/212052/65820051-c9920200-e224-11e9-895e-f50c0e833da2.png">
