### PR TITLE
Fix performance tests

### DIFF
--- a/Tests/SwiftPriorityQueueTests/SwiftPriorityQueuePerformanceTests.swift
+++ b/Tests/SwiftPriorityQueueTests/SwiftPriorityQueuePerformanceTests.swift
@@ -24,45 +24,47 @@ import XCTest
 @testable import SwiftPriorityQueue
 
 class SwiftPriorityQueuePerformanceTests: XCTestCase {
-
-     func testBuildPerformance() {
-           let input: [Int] = Array((0 ..< 100000))
-           measure {
-            let _: PriorityQueue<Int> = PriorityQueue(ascending: true, startingValues: input)
-           }
-       }
-       
-       func testPopPerformance() {
-        var pq = PriorityQueue(ascending: true, startingValues: Array(0 ..< 100000))
+    
+    func testBuildPerformance() {
+        let input: [Int] = Array((0 ..< 100000))
         measure {
-               for _ in 0 ..< 100000 {
-                   let _ = pq.pop()
-               }
-           }
-       }
-       
-       func testPushPerformance() {
+            let _: PriorityQueue<Int> = PriorityQueue(ascending: true, startingValues: input)
+        }
+    }
+    
+    func testPopPerformance() {
+        let original = PriorityQueue(ascending: true, startingValues: Array(0 ..< 100000))
+        measure {
+            var pq = original
+            for _ in 0 ..< 100000 {
+                let _ = pq.pop()
+            }
+        }
+    }
+    
+    func testPushPerformance() {
+        measure {
             var pq = PriorityQueue<Int>(ascending: true, startingValues: [])
-            measure {
-               for i in 0 ..< 100000 {
-                   pq.push(i)
-               }
-           }
-       }
-       
-       func testRemovePerformance() {
-           var pq = PriorityQueue(ascending: true, startingValues: Array(0 ..< 10000))
-           measure {
+            for i in 0 ..< 100000 {
+                pq.push(i)
+            }
+        }
+    }
+    
+    func testRemovePerformance() {
+        let original = PriorityQueue(ascending: true, startingValues: Array(0 ..< 10000))
+        measure {
+            var pq = original
             for x in 0 ..< 100 {
-                   pq.remove(x * x)
-               }
-           }
-       }
-
+                pq.remove(x * x)
+            }
+        }
+    }
+    
     static var allTests = [
-    ("testBuildPerformance", testBuildPerformance),
-    ("testPopPerformance", testPopPerformance),
-    ("testPushPerformance", testPushPerformance),
-    ("testRemovePerformance", testRemovePerformance)
+        ("testBuildPerformance", testBuildPerformance),
+        ("testPopPerformance", testPopPerformance),
+        ("testPushPerformance", testPushPerformance),
+        ("testRemovePerformance", testRemovePerformance)
     ]
 }

--- a/Tests/SwiftPriorityQueueTests/SwiftPriorityQueuePerformanceTests.swift
+++ b/Tests/SwiftPriorityQueueTests/SwiftPriorityQueuePerformanceTests.swift
@@ -44,8 +44,8 @@ class SwiftPriorityQueuePerformanceTests: XCTestCase {
     
     func testPushPerformance() {
         measure {
-            var pq = PriorityQueue<Int>(ascending: true, startingValues: [])
             for i in 0 ..< 100000 {
+                var pq = PriorityQueue<Int>(ascending: true, startingValues: [])
                 pq.push(i)
             }
         }


### PR DESCRIPTION
Change code like

```
var pq = …
measure {
    [mutate pq]
}
```
into code like
```
let original = …
measure {
    var pq = original
    [mutate pq]
}
```

Since the `measure` block executes multiple times, the variable is otherwise different on successive calls.

(The change looks more than it is since the indentation is also fixed!)