### PR TITLE
Get rid of Collection conformance or implement it differently

### DIFF
--- a/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
+++ b/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
@@ -56,9 +56,13 @@ public struct PriorityQueue<T: Comparable> {
     }
     
     /// How many elements the Priority Queue stores
+    ///
+    /// - Complexity: O(1)
     public var count: Int { return heap.count }
     
     /// true if and only if the Priority Queue is empty
+    ///
+    /// - Complexity: O(1)
     public var isEmpty: Bool { return heap.isEmpty }
     
     /// Add a new element onto the Priority Queue. O(lg n)
@@ -190,13 +194,34 @@ extension PriorityQueue: Collection {
     public typealias Index = Int
     
     public var startIndex: Int { return heap.startIndex }
+    
     public var endIndex: Int { return heap.endIndex }
     
-    public subscript(i: Int) -> T { return heap[i] }
+    /// Return the element at specified position.
+    ///
+    /// - Parameter position:   the index of the element to retireve.
+    ///                         **Must not be negative**
+    ///                         and **must be less greater than **
+    ///                         `endindex`.
+    /// - Complexity: O(log *n*) where *n* is the count of elements stored
+    ///               in the instance.
+    /// - Returns: the element at the specified position.
+    public subscript(position: Int) -> T {
+        precondition(
+            startIndex..<endIndex ~= position,
+            "SwiftPriorityQueue subscript: index out of bounds"
+        )
+        for (idx, element) in enumerated() where idx == position {
+            return element
+        }
+        preconditionFailure("SwiftPriorityQueue subscript: index out of bounds")
+    }
     
     public func index(after i: PriorityQueue.Index) -> PriorityQueue.Index {
         return heap.index(after: i)
     }
+    
+    
 }
 
 // MARK: - CustomStringConvertible, CustomDebugStringConvertible

--- a/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
+++ b/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
@@ -31,7 +31,7 @@
 /// at the time of initialization.
 public struct PriorityQueue<T: Comparable> {
     
-    fileprivate var heap = [T]()
+    fileprivate(set) var heap = [T]()
     private let ordered: (T, T) -> Bool
     
     public init(ascending: Bool = false, startingValues: [T] = []) {

--- a/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
+++ b/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
@@ -38,6 +38,41 @@ import Foundation
 
 class SwiftPriorityQueueTests: XCTestCase {
     
+    func testFastIteratingReturnsValuesInSameOrderOfIndexIteration() {
+        var pq = PriorityQueue<Int>(order: <, startingValues: [1, 2, 3, 4, 5])
+        
+        var fastIterationValues = [Int]()
+        var iter = pq.makeIterator()
+        while let element = iter.next() {
+            fastIterationValues.append(element)
+        }
+        
+        var indexIterationValues = [Int]()
+        for i in pq.startIndex..<pq.endIndex {
+            indexIterationValues.append(pq[i])
+        }
+        
+        XCTAssertEqual(fastIterationValues, indexIterationValues)
+        
+        // Let's also test with the other sort:
+        fastIterationValues.removeAll(keepingCapacity: true)
+        indexIterationValues.removeAll(keepingCapacity: true)
+        pq = PriorityQueue<Int>(order: >, startingValues: [5, 4, 3, 2, 1])
+        
+        iter = pq.makeIterator()
+        while let element = iter.next() {
+            fastIterationValues.append(element)
+        }
+        
+        var indexIterationValue = [Int]()
+        for i in pq.startIndex..<pq.endIndex {
+            indexIterationValue.append(pq[i])
+        }
+        
+        XCTAssertEqual(fastIterationValues, indexIterationValue)
+        
+    }
+    
     func testCustomOrder() {
         let priorities = [0: 5000, 1: 4000, 2: 3000, 3: 2000, 4: 1000, 5: 0]
         var pq: PriorityQueue<Int> = PriorityQueue<Int>(order: { priorities[$0]! > priorities[$1]! })

--- a/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
+++ b/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
@@ -70,7 +70,23 @@ class SwiftPriorityQueueTests: XCTestCase {
         }
         
         XCTAssertEqual(fastIterationValues, indexIterationValue)
+    }
+    
+    func testIteratingViaIndexesValueSemantics() {
+        var pq = PriorityQueue<Int>(order: <, startingValues: [1, 2, 3, 4, 5])
+        var expectedHeap = pq.heap
+        for i in pq.indices {
+            let _ = pq[i]
+        }
+        XCTAssertEqual(pq.heap, expectedHeap)
         
+        // Let's also test with the other sort:
+        pq = PriorityQueue<Int>(order: >, startingValues: [5, 4, 3, 2, 1])
+        expectedHeap = pq.heap
+        for i in pq.indices {
+            let _ = pq[i]
+        }
+        XCTAssertEqual(pq.heap, expectedHeap)
     }
     
     func testCustomOrder() {


### PR DESCRIPTION
Added test showing that Collection conformance doesn't match the Sequ…ence conformance: when iterating elements via iterator the PriorityQueue uses the pop() method, effectively returning the elements in order. On the other hand if one iterates via indexes subscription, the elements are returned in the same order as they are stored in the underlaying storage, which doesn't necessarily matches the order in which elements are popped via the pop() method.

Fix: get rid of Collection conformance, otherwise implement a different Index type which takes into account how the effective order elements are popped out from the storage (most likely subscripting or creation of indexes won't be an O(1) operation).