### PR TITLE
Support for top-n 'inverted' PQ with limited heap size

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Or you can specify neither. By default a `PriorityQueue` is descending and empty
 ### Methods
 `PriorityQueue` has all of the standard methods you'd expect a priority queue data structure to have.
 * `push(element: T)` - Puts an element into the priority queue. O(lg n)
+* `push(element: T, maxHeap: Int)` - Attempts to put an element into an ‘inverted’ priority queue, with limitation on heap size. O(lg n)
 * `pop() -> T?` - Returns and removes the element with the highest (or lowest if ascending) priority or `nil` if the priority queue is empty. O(lg n)
 * `peek() -> T?` - Returns the element with the highest (or lowest if ascending) priority or `nil` if the priority queue is empty. O(1)
 * `clear()` - Removes all elements from the priority queue.
@@ -78,6 +79,29 @@ When you do this, every item from the `PriorityQueue` is popped in order. `Prior
 print(pq)
 ```
 Note: `PriorityQueue` is *not* thread-safe (do not manipulate it from multiple threads at once).
+
+### Limited Heap Size Example
+
+Two use cases in which you'll want to limit the heap size of a Priority Queue:
+
+1. Bulk insertion of data where memory is constrained.
+2. Only the ‘head’ of the Priority Queue is relevant and the ‘tail’ can be ignored.
+
+In such cases, create an ‘inverted’ Priority Queue (where the sort is reversed) and use the `push(element: T, maxHeap: Int)` method to add items to the queue. For example, where you want to prioritize the first four(4) elements in ascending order:
+
+```
+var pq: PriorityQueue<Int> = PriorityQueue<Int>(ascending: false)  // inverted!
+let maxHeap = 4         
+                        // pq.reversed() output shown
+pq.push(4, maxHeap)     // [4]
+pq.push(5, maxHeap)     // [4, 5]
+pq.push(0, maxHeap)     // [0, 4, 5]
+pq.push(3, maxHeap)     // [0, 3, 4, 5]
+pq.push(6, maxHeap)     // [0, 3, 4, 5] (push of 6 is ignored)
+pq.push(1, maxHeap)     // [0, 1, 3, 4] (5 is discarded)
+```
+
+Note the use of `pq.reversed()` to show the values in ascending order.
 
 ### Just for Fun - A* (`astar.swift`)
 A* is a pathfinding algorithm that uses a priority queue. The sample program that comes with SwiftPriorityQueue is a maze solver that uses A*. You can find some in-source documentation if you want to reuse this algorithm inside `astar.swift`.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Or you can specify neither. By default a `PriorityQueue` is descending and empty
 ### Methods
 `PriorityQueue` has all of the standard methods you'd expect a priority queue data structure to have.
 * `push(element: T)` - Puts an element into the priority queue. O(lg n)
-* `push(element: T, maxCount: Int) -> T?` - Adds an element while limiting the size of the priority queue to `maxCount`. If more than `maxCount` elements are in the priority queue, `maxCount - count` elements will be popped. Only the lowest priority items will be removed. The first element popped will be returned or `nil` if nothing is popped. O(n lg n)
+* `push(element: T, maxCount: Int) -> T?` - Adds an element while limiting the size of the priority queue to `maxCount`. If more than `maxCount` elements are in the priority queue after the addition, the lowest priority element will be discarded and returned. Note this is inefficient because this is a binary heap, so only the highet priority item is efficient to retrieve. O(n)
 * `pop() -> T?` - Returns and removes the element with the highest (or lowest if ascending) priority or `nil` if the priority queue is empty. O(lg n)
 * `peek() -> T?` - Returns the element with the highest (or lowest if ascending) priority or `nil` if the priority queue is empty. O(1)
 * `clear()` - Removes all elements from the priority queue.
@@ -84,21 +84,21 @@ Note: `PriorityQueue` is *not* thread-safe (do not manipulate it from multiple t
 
 Suppose you want to only keep the `maxCount` highest priority items in the priority queue.
 
-For example, say you only want the priority queue to ever have 4 elements:
+For example, say you only want the priority queue to only ever have 4 elements:
 
 ```
 var pq: PriorityQueue<Int> = PriorityQueue<Int>()
-let maxHeap = 4         
+let maxCount = 4         
 
-pq.push(4, maxHeap)
-pq.push(5, maxHeap)
-pq.push(0, maxHeap)
-pq.push(3, maxHeap)  
-pq.push(6, maxHeap)     
-pq.push(1, maxHeap)     
+pq.push(4, maxCount: maxCount)
+pq.push(5, maxCount: maxCount)
+pq.push(0, maxCount: maxCount)
+pq.push(3, maxCount: maxCount)  
+pq.push(6, maxCount: maxCount)     
+pq.push(1, maxCount: maxCount)     
 ```
 
-In this case, after 4 elements were pushed, only the largest elements were kept (because the order was `ascending`). So, the final priority queue has the elements 0, 1, 3, 4 in it. 
+In this case, after 4 elements were pushed, only the smallest elements were kept (because the order was `ascending`). So, the final priority queue has the elements 0, 1, 3, 4 in it. 
 
 ### Just for Fun - A* (`astar.swift`)
 A* is a pathfinding algorithm that uses a priority queue. The sample program that comes with SwiftPriorityQueue is a maze solver that uses A*. You can find some in-source documentation if you want to reuse this algorithm inside `astar.swift`.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Or you can specify neither. By default a `PriorityQueue` is descending and empty
 ### Methods
 `PriorityQueue` has all of the standard methods you'd expect a priority queue data structure to have.
 * `push(element: T)` - Puts an element into the priority queue. O(lg n)
-* `push(element: T, maxHeap: Int)` - Attempts to put an element into an ‘inverted’ priority queue, with limitation on heap size. O(lg n)
+* `push(element: T, maxCount: Int) -> T?` - Adds an element while limiting the size of the priority queue to `maxCount`. If more than `maxCount` elements are in the priority queue, `maxCount - count` elements will be popped. Only the lowest priority items will be removed. The first element popped will be returned or `nil` if nothing is popped. O(n lg n)
 * `pop() -> T?` - Returns and removes the element with the highest (or lowest if ascending) priority or `nil` if the priority queue is empty. O(lg n)
 * `peek() -> T?` - Returns the element with the highest (or lowest if ascending) priority or `nil` if the priority queue is empty. O(1)
 * `clear()` - Removes all elements from the priority queue.
@@ -82,29 +82,26 @@ Note: `PriorityQueue` is *not* thread-safe (do not manipulate it from multiple t
 
 ### Limited Heap Size Example
 
-Two use cases in which you'll want to limit the heap size of a Priority Queue:
+Suppose you want to only keep the `maxCount` highest priority items in the priority queue.
 
-1. Bulk insertion of data where memory is constrained.
-2. Only the ‘head’ of the Priority Queue is relevant and the ‘tail’ can be ignored.
-
-In such cases, create an ‘inverted’ Priority Queue (where the sort is reversed) and use the `push(element: T, maxHeap: Int)` method to add items to the queue. For example, where you want to prioritize the first four(4) elements in ascending order:
+For example, say you only want the priority queue to ever have 4 elements:
 
 ```
-var pq: PriorityQueue<Int> = PriorityQueue<Int>(ascending: false)  // inverted!
+var pq: PriorityQueue<Int> = PriorityQueue<Int>()
 let maxHeap = 4         
-                        // pq.reversed() output shown
-pq.push(4, maxHeap)     // [4]
-pq.push(5, maxHeap)     // [4, 5]
-pq.push(0, maxHeap)     // [0, 4, 5]
-pq.push(3, maxHeap)     // [0, 3, 4, 5]
-pq.push(6, maxHeap)     // [0, 3, 4, 5] (push of 6 is ignored)
-pq.push(1, maxHeap)     // [0, 1, 3, 4] (5 is discarded)
+
+pq.push(4, maxHeap)
+pq.push(5, maxHeap)
+pq.push(0, maxHeap)
+pq.push(3, maxHeap)  
+pq.push(6, maxHeap)     
+pq.push(1, maxHeap)     
 ```
 
-Note the use of `pq.reversed()` to show the values in ascending order.
+In this case, after 4 elements were pushed, only the largest elements were kept (because the order was `ascending`). So, the final priority queue has the elements 0, 1, 3, 4 in it. 
 
 ### Just for Fun - A* (`astar.swift`)
 A* is a pathfinding algorithm that uses a priority queue. The sample program that comes with SwiftPriorityQueue is a maze solver that uses A*. You can find some in-source documentation if you want to reuse this algorithm inside `astar.swift`.
 
 ## Authorship & License
-SwiftPriorityQueue is written by David Kopec and released under the MIT License (see `LICENSE`). You can find my email address on my GitHub profile page. I encourage you to submit pull requests and open issues here on GitHub.
+SwiftPriorityQueue is written by David Kopec (@davecom on GitHub) and released under the MIT License (see `LICENSE`). You can find my contact information on my GitHub profile page. I encourage you to submit pull requests and open issues here on GitHub. Thank you to all of the contributors over the years.

--- a/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
+++ b/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
@@ -56,9 +56,13 @@ public struct PriorityQueue<T: Comparable> {
     }
     
     /// How many elements the Priority Queue stores
+    ///
+    /// - Complexity: O(1)
     public var count: Int { return heap.count }
     
     /// true if and only if the Priority Queue is empty
+    ///
+    /// - Complexity: O(1)
     public var isEmpty: Bool { return heap.isEmpty }
     
     /// Add a new element onto the Priority Queue. O(lg n)
@@ -190,13 +194,34 @@ extension PriorityQueue: Collection {
     public typealias Index = Int
     
     public var startIndex: Int { return heap.startIndex }
+    
     public var endIndex: Int { return heap.endIndex }
     
-    public subscript(i: Int) -> T { return heap[i] }
+    /// Return the element at specified position.
+    ///
+    /// - Parameter position:   the index of the element to retireve.
+    ///                         **Must not be negative**
+    ///                         and **must be less greater than **
+    ///                         `endindex`.
+    /// - Complexity: O(log *n*) where *n* is the count of elements stored
+    ///               in the instance.
+    /// - Returns: the element at the specified position.
+    public subscript(position: Int) -> T {
+        precondition(
+            startIndex..<endIndex ~= position,
+            "SwiftPriorityQueue subscript: index out of bounds"
+        )
+        for (idx, element) in enumerated() where idx == position {
+            return element
+        }
+        preconditionFailure("SwiftPriorityQueue subscript: index out of bounds")
+    }
     
     public func index(after i: PriorityQueue.Index) -> PriorityQueue.Index {
         return heap.index(after: i)
     }
+    
+    
 }
 
 // MARK: - CustomStringConvertible, CustomDebugStringConvertible

--- a/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
+++ b/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
@@ -31,7 +31,7 @@
 /// at the time of initialization.
 public struct PriorityQueue<T: Comparable> {
     
-    fileprivate var heap = [T]()
+    fileprivate(set) var heap = [T]()
     private let ordered: (T, T) -> Bool
     
     public init(ascending: Bool = false, startingValues: [T] = []) {

--- a/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
+++ b/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
@@ -87,14 +87,15 @@ public struct PriorityQueue<T: Comparable> {
         precondition(maxCount > 0)
         if maxCount <= count {
             push(element)
-            return nil
         } else { // heap.count > maxCount
             // find the min priority element
-            var discard: T? = heap.min(by: ordered)
-            if ordered(element, discard) { return element }
-            remove(discard)
-            return discard
+            if let discard = heap.min(by: ordered) {
+                if ordered(element, discard) { return element }
+                remove(discard)
+                return discard
+            }
         }
+        return nil
     }
 
     /// Remove and return the element with the highest priority (or lowest if ascending). O(lg n)
@@ -234,7 +235,7 @@ extension PriorityQueue: Collection {
             startIndex..<endIndex ~= position,
             "SwiftPriorityQueue subscript: index out of bounds"
         )
-        return heap[i]
+        return heap[position]
     }
     
     public func index(after i: PriorityQueue.Index) -> PriorityQueue.Index {

--- a/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
+++ b/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
@@ -32,7 +32,7 @@
 public struct PriorityQueue<T: Comparable> {
     
     fileprivate(set) var heap = [T]()
-    private let ordered: (T, T) -> Bool
+    private var ordered: (T, T) -> Bool
     
     public init(ascending: Bool = false, startingValues: [T] = []) {
         self.init(order: ascending ? { $0 > $1 } : { $0 < $1 }, startingValues: startingValues)
@@ -140,8 +140,9 @@ public struct PriorityQueue<T: Comparable> {
         return heap.first
     }
     
-    /// Eliminate all of the elements from the Priority Queue.
-    public mutating func clear() {
+    /// Eliminate all of the elements from the Priority Queue, optionally replacing the order.
+    public mutating func clear(newOrder: ((T, T) -> Bool)? = nil) {
+        if let _newOrder = newOrder { self.ordered = _newOrder }
         heap.removeAll(keepingCapacity: false)
     }
     

--- a/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
+++ b/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
@@ -69,6 +69,21 @@ public struct PriorityQueue<T: Comparable> {
         swim(heap.count - 1)
     }
     
+    /// Attempt to add a new element onto an 'inverted' Priority Queue, limiting its size. O(lg n)
+    ///
+    /// If the size limit has been reached and the element falls beyond the 'tail', it will be ignored.  If pushed, a single element at the 'tail' will be popped.
+    ///
+    /// - parameter element: The element to be attempted insertion into the Priority Queue.
+    /// - parameter maxHeap: The Priority Queue will not grow further if its size >= maxHeap.
+    public mutating func push(_ element: T, maxHeap: Int) {
+        precondition(maxHeap > 0)
+        if heap.count >= maxHeap {
+            if let peeked = peek(), !ordered(element, peeked) { return }
+            _ = pop()
+        }
+        push(element)
+    }
+
     /// Remove and return the element with the highest priority (or lowest if ascending). O(lg n)
     ///
     /// - returns: The element with the highest priority in the Priority Queue, or nil if the PriorityQueue is empty.

--- a/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
+++ b/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
@@ -79,13 +79,15 @@ public struct PriorityQueue<T: Comparable> {
     ///
     /// - parameter element: The element to be attempted insertion into the Priority Queue.
     /// - parameter maxHeap: The Priority Queue will not grow further if its size >= maxHeap.
-    public mutating func push(_ element: T, maxHeap: Int) {
+    public mutating func push(_ element: T, maxHeap: Int) -> T? {
         precondition(maxHeap > 0)
+        var discard: T?
         if heap.count >= maxHeap {
-            if let peeked = peek(), !ordered(element, peeked) { return }
-            _ = pop()
+            if let peeked = peek(), !ordered(element, peeked) { return nil }
+            discard = pop()
         }
         push(element)
+        return discard
     }
 
     /// Remove and return the element with the highest priority (or lowest if ascending). O(lg n)

--- a/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
+++ b/Sources/SwiftPriorityQueue/SwiftPriorityQueue.swift
@@ -74,22 +74,27 @@ public struct PriorityQueue<T: Comparable> {
         swim(heap.count - 1)
     }
     
-    /// Add a new element onto a Priority Queue, limiting its size. O(n lg n)
-    /// If the size limit has been reached, `maxCount` - `count` elements will be popped.
+    /// Add a new element onto a Priority Queue, limiting the size of the queue. O(n^2)
+    /// If the size limit has been reached, the lowest priority element will be removed and returned.
+    /// Note that because this is a binary heap, there is no easy way to find the lowest priority
+    /// item, so this method can be inefficient.
+    /// Also note, that only one item will be removed, even if count > maxCount by more than one.
     ///
-    /// - parameter element: The element to be attempted insertion into the Priority Queue.
+    /// - parameter element: The element to be inserted into the Priority Queue.
     /// - parameter maxCount: The Priority Queue will not grow further if its count >= maxCount.
-    /// - returns: the first element popped, or `nil` if no elements were popped
+    /// - returns: the discarded lowest priority element, or `nil` if count < maxCount
     public mutating func push(_ element: T, maxCount: Int) -> T? {
         precondition(maxCount > 0)
-        push(element)
-        if heap.count >= maxCount {
-            var discard: T?
-            discard = pop()
-            while heap.count >= maxCount { pop() }
+        if maxCount <= count {
+            push(element)
+            return nil
+        } else { // heap.count > maxCount
+            // find the min priority element
+            var discard: T? = heap.min(by: ordered)
+            if ordered(element, discard) { return element }
+            remove(discard)
             return discard
         }
-        return nil
     }
 
     /// Remove and return the element with the highest priority (or lowest if ascending). O(lg n)

--- a/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
+++ b/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
@@ -38,6 +38,41 @@ import Foundation
 
 class SwiftPriorityQueueTests: XCTestCase {
     
+    func testFastIteratingReturnsValuesInSameOrderOfIndexIteration() {
+        var pq = PriorityQueue<Int>(order: <, startingValues: [1, 2, 3, 4, 5])
+        
+        var fastIterationValues = [Int]()
+        var iter = pq.makeIterator()
+        while let element = iter.next() {
+            fastIterationValues.append(element)
+        }
+        
+        var indexIterationValues = [Int]()
+        for i in pq.startIndex..<pq.endIndex {
+            indexIterationValues.append(pq[i])
+        }
+        
+        XCTAssertEqual(fastIterationValues, indexIterationValues)
+        
+        // Let's also test with the other sort:
+        fastIterationValues.removeAll(keepingCapacity: true)
+        indexIterationValues.removeAll(keepingCapacity: true)
+        pq = PriorityQueue<Int>(order: >, startingValues: [5, 4, 3, 2, 1])
+        
+        iter = pq.makeIterator()
+        while let element = iter.next() {
+            fastIterationValues.append(element)
+        }
+        
+        var indexIterationValue = [Int]()
+        for i in pq.startIndex..<pq.endIndex {
+            indexIterationValue.append(pq[i])
+        }
+        
+        XCTAssertEqual(fastIterationValues, indexIterationValue)
+        
+    }
+    
     func testCustomOrder() {
         let priorities = [0: 5000, 1: 4000, 2: 3000, 3: 2000, 4: 1000, 5: 0]
         var pq: PriorityQueue<Int> = PriorityQueue<Int>(order: { priorities[$0]! > priorities[$1]! })

--- a/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
+++ b/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
@@ -103,21 +103,6 @@ class SwiftPriorityQueueTests: XCTestCase {
         }
         
         XCTAssertEqual(expected, actual)
-        
-        // Let's also test replacing the order
-        pq.clear(newOrder: { priorities[$0]! < priorities[$1]! })
-        
-        for i in 0...5 {
-            pq.push(i);
-        }
-        
-        let expected2: [Int] = [0, 1, 2, 3, 4, 5]
-        var actual2: [Int] = []
-        for j in pq {
-            actual2.append(j)
-        }
-        
-        XCTAssertEqual(expected2, actual2)
     }
     
     func testBasic() {

--- a/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
+++ b/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
@@ -226,36 +226,36 @@ class SwiftPriorityQueueTests: XCTestCase {
     func testPushWithLimitAscending() {
         var pq: PriorityQueue<Int> = PriorityQueue<Int>(ascending: false)   // inverted
         let maxHeap = 4
-        pq.push(4, maxHeap: maxHeap)
+        XCTAssertNil(pq.push(4, maxHeap: maxHeap))
         XCTAssertEqual([4], pq.reversed())
-        pq.push(5, maxHeap: maxHeap)
+        XCTAssertNil(pq.push(5, maxHeap: maxHeap))
         XCTAssertEqual([4, 5], pq.reversed())
-        pq.push(0, maxHeap: maxHeap)
+        XCTAssertNil(pq.push(0, maxHeap: maxHeap))
         XCTAssertEqual([0, 4, 5], pq.reversed())
-        pq.push(3, maxHeap: maxHeap)
+        XCTAssertNil(pq.push(3, maxHeap: maxHeap))
         XCTAssertEqual([0, 3, 4, 5], pq.reversed())
-        pq.push(6, maxHeap: maxHeap)
+        XCTAssertNil(pq.push(6, maxHeap: maxHeap))
         XCTAssertEqual([0, 3, 4, 5], pq.reversed())
-        pq.push(1, maxHeap: maxHeap)
+        XCTAssertEqual(5, pq.push(1, maxHeap: maxHeap))
         XCTAssertEqual([0, 1, 3, 4], pq.reversed())
     }
     
     func testPushWithLimitDescending() {
         var pq: PriorityQueue<Int> = PriorityQueue<Int>(ascending: true)    // inverted
         let maxHeap = 4
-        pq.push(4, maxHeap: maxHeap)
+        XCTAssertNil(pq.push(4, maxHeap: maxHeap))
         XCTAssertEqual([4], pq.reversed())
-        pq.push(5, maxHeap: maxHeap)
+        XCTAssertNil(pq.push(5, maxHeap: maxHeap))
         XCTAssertEqual([5, 4], pq.reversed())
-        pq.push(2, maxHeap: maxHeap)
+        XCTAssertNil(pq.push(2, maxHeap: maxHeap))
         XCTAssertEqual([5, 4, 2], pq.reversed())
-        pq.push(3, maxHeap: maxHeap)
+        XCTAssertNil(pq.push(3, maxHeap: maxHeap))
         XCTAssertEqual([5, 4, 3, 2], pq.reversed())
-        pq.push(1, maxHeap: maxHeap)
+        XCTAssertNil(pq.push(1, maxHeap: maxHeap))
         XCTAssertEqual([5, 4, 3, 2], pq.reversed())
-        pq.push(6, maxHeap: maxHeap)
+        XCTAssertEqual(2, pq.push(6, maxHeap: maxHeap))
         XCTAssertEqual([6, 5, 4, 3], pq.reversed())
-        pq.push(6, maxHeap: maxHeap)
+        XCTAssertEqual(3, pq.push(6, maxHeap: maxHeap))
         XCTAssertEqual([6, 6, 5, 4], pq.reversed())
     }
     

--- a/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
+++ b/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
@@ -171,6 +171,42 @@ class SwiftPriorityQueueTests: XCTestCase {
         
         XCTAssertEqual(expected, actual)
     }
+
+    func testPushWithLimitAscending() {
+        var pq: PriorityQueue<Int> = PriorityQueue<Int>(ascending: false)   // inverted
+        let maxHeap = 4
+        pq.push(4, maxHeap: maxHeap)
+        XCTAssertEqual([4], pq.reversed())
+        pq.push(5, maxHeap: maxHeap)
+        XCTAssertEqual([4, 5], pq.reversed())
+        pq.push(0, maxHeap: maxHeap)
+        XCTAssertEqual([0, 4, 5], pq.reversed())
+        pq.push(3, maxHeap: maxHeap)
+        XCTAssertEqual([0, 3, 4, 5], pq.reversed())
+        pq.push(6, maxHeap: maxHeap)
+        XCTAssertEqual([0, 3, 4, 5], pq.reversed())
+        pq.push(1, maxHeap: maxHeap)
+        XCTAssertEqual([0, 1, 3, 4], pq.reversed())
+    }
+    
+    func testPushWithLimitDescending() {
+        var pq: PriorityQueue<Int> = PriorityQueue<Int>(ascending: true)    // inverted
+        let maxHeap = 4
+        pq.push(4, maxHeap: maxHeap)
+        XCTAssertEqual([4], pq.reversed())
+        pq.push(5, maxHeap: maxHeap)
+        XCTAssertEqual([5, 4], pq.reversed())
+        pq.push(2, maxHeap: maxHeap)
+        XCTAssertEqual([5, 4, 2], pq.reversed())
+        pq.push(3, maxHeap: maxHeap)
+        XCTAssertEqual([5, 4, 3, 2], pq.reversed())
+        pq.push(1, maxHeap: maxHeap)
+        XCTAssertEqual([5, 4, 3, 2], pq.reversed())
+        pq.push(6, maxHeap: maxHeap)
+        XCTAssertEqual([6, 5, 4, 3], pq.reversed())
+        pq.push(6, maxHeap: maxHeap)
+        XCTAssertEqual([6, 6, 5, 4], pq.reversed())
+    }
     
     static var allTests = [
         ("testCustomOrder", testCustomOrder),
@@ -182,5 +218,7 @@ class SwiftPriorityQueueTests: XCTestCase {
         ("testRemove", testRemove),
         ("testRemoveAll", testRemoveAll),
         ("testRemoveLastInHeap", testRemoveLastInHeap),
+        ("testPushWithLimitAscending", testPushWithLimitAscending),
+        ("testPushWithLimitDescending", testPushWithLimitDescending),
         ]
 }

--- a/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
+++ b/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
@@ -2,7 +2,7 @@
 //  SwiftPriorityQueueTests.swift
 //  SwiftPriorityQueue
 //
-//  Copyright (c) 2015-2019 David Kopec
+//  Copyright (c) 2015-2023 David Kopec
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -240,37 +240,37 @@ class SwiftPriorityQueueTests: XCTestCase {
 
     func testPushWithLimitAscending() {
         var pq: PriorityQueue<Int> = PriorityQueue<Int>(ascending: false)   // inverted
-        let maxHeap = 4
-        XCTAssertNil(pq.push(4, maxHeap: maxHeap))
+        let maxCount = 4
+        XCTAssertNil(pq.push(4, maxCount: maxCount))
         XCTAssertEqual([4], pq.reversed())
-        XCTAssertNil(pq.push(5, maxHeap: maxHeap))
+        XCTAssertNil(pq.push(5, maxCount: maxCount))
         XCTAssertEqual([4, 5], pq.reversed())
-        XCTAssertNil(pq.push(0, maxHeap: maxHeap))
+        XCTAssertNil(pq.push(0, maxCount: maxCount))
         XCTAssertEqual([0, 4, 5], pq.reversed())
-        XCTAssertNil(pq.push(3, maxHeap: maxHeap))
+        XCTAssertNil(pq.push(3, maxCount: maxCount))
         XCTAssertEqual([0, 3, 4, 5], pq.reversed())
-        XCTAssertNil(pq.push(6, maxHeap: maxHeap))
+        XCTAssertNil(pq.push(6, maxCount: maxCount))
         XCTAssertEqual([0, 3, 4, 5], pq.reversed())
-        XCTAssertEqual(5, pq.push(1, maxHeap: maxHeap))
+        XCTAssertEqual(5, pq.push(1, maxCount: maxCount))
         XCTAssertEqual([0, 1, 3, 4], pq.reversed())
     }
     
     func testPushWithLimitDescending() {
         var pq: PriorityQueue<Int> = PriorityQueue<Int>(ascending: true)    // inverted
-        let maxHeap = 4
-        XCTAssertNil(pq.push(4, maxHeap: maxHeap))
+        let maxCount = 4
+        XCTAssertNil(pq.push(4, maxCount: maxCount))
         XCTAssertEqual([4], pq.reversed())
-        XCTAssertNil(pq.push(5, maxHeap: maxHeap))
+        XCTAssertNil(pq.push(5, maxCount: maxCount))
         XCTAssertEqual([5, 4], pq.reversed())
-        XCTAssertNil(pq.push(2, maxHeap: maxHeap))
+        XCTAssertNil(pq.push(2, maxCount: maxCount))
         XCTAssertEqual([5, 4, 2], pq.reversed())
-        XCTAssertNil(pq.push(3, maxHeap: maxHeap))
+        XCTAssertNil(pq.push(3, maxCount: maxCount))
         XCTAssertEqual([5, 4, 3, 2], pq.reversed())
-        XCTAssertNil(pq.push(1, maxHeap: maxHeap))
+        XCTAssertNil(pq.push(1, maxCount: maxCount))
         XCTAssertEqual([5, 4, 3, 2], pq.reversed())
-        XCTAssertEqual(2, pq.push(6, maxHeap: maxHeap))
+        XCTAssertEqual(2, pq.push(6, maxCount: maxCount))
         XCTAssertEqual([6, 5, 4, 3], pq.reversed())
-        XCTAssertEqual(3, pq.push(6, maxHeap: maxHeap))
+        XCTAssertEqual(3, pq.push(6, maxCount: maxCount))
         XCTAssertEqual([6, 6, 5, 4], pq.reversed())
     }
     

--- a/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
+++ b/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
@@ -70,7 +70,23 @@ class SwiftPriorityQueueTests: XCTestCase {
         }
         
         XCTAssertEqual(fastIterationValues, indexIterationValue)
+    }
+    
+    func testIteratingViaIndexesValueSemantics() {
+        var pq = PriorityQueue<Int>(order: <, startingValues: [1, 2, 3, 4, 5])
+        var expectedHeap = pq.heap
+        for i in pq.indices {
+            let _ = pq[i]
+        }
+        XCTAssertEqual(pq.heap, expectedHeap)
         
+        // Let's also test with the other sort:
+        pq = PriorityQueue<Int>(order: >, startingValues: [5, 4, 3, 2, 1])
+        expectedHeap = pq.heap
+        for i in pq.indices {
+            let _ = pq[i]
+        }
+        XCTAssertEqual(pq.heap, expectedHeap)
     }
     
     func testCustomOrder() {

--- a/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
+++ b/Tests/SwiftPriorityQueueTests/SwiftPriorityQueueTests.swift
@@ -103,6 +103,21 @@ class SwiftPriorityQueueTests: XCTestCase {
         }
         
         XCTAssertEqual(expected, actual)
+        
+        // Let's also test replacing the order
+        pq.clear(newOrder: { priorities[$0]! < priorities[$1]! })
+        
+        for i in 0...5 {
+            pq.push(i);
+        }
+        
+        let expected2: [Int] = [0, 1, 2, 3, 4, 5]
+        var actual2: [Int] = []
+        for j in pq {
+            actual2.append(j)
+        }
+        
+        XCTAssertEqual(expected2, actual2)
     }
     
     func testBasic() {


### PR DESCRIPTION
At the time, I'd updated the README and added unit test coverage.

The complexity expressions I included may be bogus, as my expertise is lacking. Please review and correct as needed!

Note: this appears to incorporate changes from a @vale-cocoa fork, which I must have merged at the time. My GitHub foo is insufficient to exclude them.